### PR TITLE
Add equivalent Github Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on: workflow_dispatch
 
 env:
   # Remember to convert to secret variables before merging
-  SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
+  #   SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   REGION: eastus2
   CLUSTER_NAME: githubrunner
@@ -30,7 +30,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       # Runs a single command using the runners shell
       - name: Run setup.sh
-        run: . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
+        run: |
+          export SUBSCRIPTION_ID=$(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
+          . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,7 @@ on: [push, workflow_dispatch]
 
 env:
   # Remember to convert to secret variables before merging
-  #   SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
-  AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+  SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .subscriptionId)
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   REGION: eastus2
   CLUSTER_NAME: githubrunner
@@ -33,7 +32,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run setup.sh
         run: |
-          export SUBSCRIPTION_ID=$(echo $AZURE_CREDENTIALS | jq -r .subscriptionId)
+          export SUBSCRIPTION_ID=$(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .subscriptionId)
           . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,16 +3,18 @@
 name: AKS Self Hosted Runner
 
 # Controls when the workflow will run
-on: workflow_dispatch
+on: [push, workflow_dispatch]
 
 env:
   # Remember to convert to secret variables before merging
   #   SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
+  AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   REGION: eastus2
   CLUSTER_NAME: githubrunner
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
+  
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -31,7 +33,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run setup.sh
         run: |
-          export SUBSCRIPTION_ID=$(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .subscriptionId)
+          export SUBSCRIPTION_ID=$(echo $AZURE_CREDENTIALS | jq -r .subscriptionId)
           . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: AKS Self Hosted Runner
+
+# Controls when the workflow will run
+on: workflow_dispatch
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,11 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run setup.sh
         run: |
-          . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
+          export STORAGE_ACCOUNT_NAME=$(echo "${RESOURCE_GROUP_NAME}" | tr '[:upper:]' '[:lower:]')$RANDOM
+          export CONTAINER_NAME=$(echo "${CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]')tfstate
+          az storage account create --resource-group $resource_group_name --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
+          export ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)
+          az storage container create --name $CONTAINER_NAME --account-name $STORAGE_ACCOUNT_NAME --account-key $ACCOUNT_KEY
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,11 +61,11 @@ jobs:
           az acr build -t ghrunner:${GITHUB_SHA} ./ghrdocker
       - name: Helm
         run: |
-          az configure --defaults acr=${CLUSTER_NAME}
-          az acr login -n ${CLUSTER_NAME}
+          # az configure --defaults acr=${CLUSTER_NAME}
+          # az acr login -n ${CLUSTER_NAME}
           cd ./ghrhelm
           helm package .
-          helm push ghr-0.0.1.tgz oci://${CLUSTER_NAME}.azurecr.io/ghrunner
+          # helm push ghr-0.0.1.tgz oci://${CLUSTER_NAME}.azurecr.io/ghrunner
       - name: AKS set context
         uses: azure/aks-set-context@v1
         with:
@@ -74,8 +74,9 @@ jobs:
           cluster-name: ${{ env.CLUSTER_NAME }}
       - name: Deploy
         run: |
-          az configure --defaults acr=${CLUSTER_NAME}
-          helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version 0.0.1
+          cd ./ghrhelm
+          # az configure --defaults acr=${CLUSTER_NAME}
+          # helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version 0.0.1
           helm install ghrunner ghr-0.0.1.tgz
             --set image.repository=${CLUSTER_NAME}.azurecr.io/ghrunner \
             --set image.tag=${GITHUB_SHA} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run setup.sh
         run: |
-          export SUBSCRIPTION_ID=$(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
+          export SUBSCRIPTION_ID=$(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .subscriptionId)
           . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,13 @@ name: AKS Self Hosted Runner
 # Controls when the workflow will run
 on: workflow_dispatch
 
+env:
+  # Remember to convert to secret variables before merging
+  RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
+  CLUSTER_NAME: githubrunner
+  GITHUB_REPO_OWNER: tristanang
+  GITHUB_REPO_NAME: aks-github-runner
+  
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -20,7 +27,7 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       # Runs a single command using the runners shell
-      - name: Run a one-line script
+      - name: Run setup.sh
         run: echo Hello, world!
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           az storage account create --resource-group $RESOURCE_GROUP_NAME --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
           ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)
           az storage container create --name $CONTAINER_NAME --account-name $STORAGE_ACCOUNT_NAME --account-key $ACCOUNT_KEY
-          echo "::set-output name=container_name::$STORAGE_ACCOUNT_NAME"
+          echo "::set-output name=storage_account_name::$STORAGE_ACCOUNT_NAME"
           echo "::set-output name=container_name::$CONTAINER_NAME"
           echo "::set-output name=account_key::$ACCOUNT_KEY"
 
@@ -41,7 +41,7 @@ jobs:
         with:
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
-          STORAGE_ACCOUNT_NAME: ${{ env.STORAGE_ACCOUNT_NAME }}
+          STORAGE_ACCOUNT_NAME: ${{ steps.setup_storage.outputs.storage_account_name }}
           STORAGE_CONTAINER_NAME: ${{ steps.setup_storage.outputs.container_name }}
           STORAGE_ACCESS_KEY: ${{ steps.setup_storage.outputs.account_key }}
           ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
   STORAGE_ACCOUNT_NAME: runnerstorage6594
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
-  GITHUB_REPO_URL: github.com/tristanang/aks-github-runner
+  GITHUB_REPO_URL: https://github.com/tristanang/aks-github-runner
   HELM_EXPERIMENTAL_OCI: 1
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           az acr login -n ${CLUSTER_NAME}
           cd ./ghrhelm
           helm package .
-          helm push ghr-${GITHUB_SHA}.tgz oci://${CLUSTER_NAME}.azurecr.io/ghrunner
+          helm push ghr-0.0.1.tgz oci://${CLUSTER_NAME}.azurecr.io/ghrunner
       - name: AKS set context
         uses: azure/aks-set-context@v1
         with:
@@ -75,8 +75,8 @@ jobs:
       - name: Deploy
         run: |
           az configure --defaults acr=${CLUSTER_NAME}
-          helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version ${GITHUB_SHA}
-          helm install ghrunner ghr-${VERSION}.tgz
+          helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version 0.0.1
+          helm install ghrunner ghr-0.0.1.tgz
             --set image.repository=${CLUSTER_NAME}.azurecr.io/ghrunner \
             --set ghr.github_token=${GH_TOKEN} \
             --set ghr.repo_name=${GITHUB_REPO_NAME} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           echo "::set-output name=account_key::$ACCOUNT_KEY"
 
       # Create AKS Cluster
-      - uses: Azure/aks_create_action@main
+      - uses: gambtho/aks_create_action@main
         with:
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
       # Runs a single command using the runners shell
       - name: Run a one-line script
         run: echo Hello, world!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on: [push, workflow_dispatch]
 
 env:
   # Remember to convert to secret variables before merging
-  SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .subscriptionId)
+  SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   REGION: eastus2
   CLUSTER_NAME: githubrunner
@@ -32,7 +32,6 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run setup.sh
         run: |
-          export SUBSCRIPTION_ID=$(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .subscriptionId)
           . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ env:
   # Remember to convert to secret variables before merging
   SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
+  REGION: eastus2
   CLUSTER_NAME: githubrunner
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
@@ -29,7 +30,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       # Runs a single command using the runners shell
       - name: Run setup.sh
-        run: echo Hello, world!
+        run: . ./setup.sh -c $CLUSTER_NAME -g $RESOURCE_GROUP_NAME -s $SUBSCRIPTION_ID -r $REGION
 
       # Runs a set of commands using the runners shell
       - name: Run a multi-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,5 +55,5 @@ jobs:
       # Build Docker image
       - name: Build image
         run: |
-          az configure --defaults acr=${RESOURCE_GROUP_NAME}
+          az configure --defaults acr=${CLUSTER_NAME}
           az acr build -t ghrunner:${GITHUB_SHA} ./ghrdocker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           export STORAGE_ACCOUNT_NAME=$(echo "${RESOURCE_GROUP_NAME}" | tr '[:upper:]' '[:lower:]')$RANDOM
           export CONTAINER_NAME=$(echo "${CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]')tfstate
-          az storage account create --resource-group $resource_group_name --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
+          az storage account create --resource-group $RESOURCE_GROUP_NAME --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
           export ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)
           az storage container create --name $CONTAINER_NAME --account-name $STORAGE_ACCOUNT_NAME --account-key $ACCOUNT_KEY
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           cd ./ghrhelm
           # az configure --defaults acr=${CLUSTER_NAME}
           # helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version 0.0.1
-          helm install ghrunner ghr-0.0.1.tgz
+          helm install ghrunner ghr-0.0.1.tgz \
             --set image.repository=${CLUSTER_NAME}.azurecr.io/ghrunner \
             --set image.tag=${GITHUB_SHA} \
             --set ghr.github_token=${GH_TOKEN} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ env:
   STORAGE_ACCOUNT_NAME: runnerstorage6594
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
+  GITHUB_REPO_URL: github.com/tristanang/aks-github-runner
+  HELM_EXPERIMENTAL_OCI: 1
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -53,7 +55,30 @@ jobs:
           ACTION_TYPE: create
           CREATE_ACR: true
       # Build Docker image
-      - name: Build image
+      - name: Build and push image
         run: |
           az configure --defaults acr=${CLUSTER_NAME}
           az acr build -t ghrunner:${GITHUB_SHA} ./ghrdocker
+      - name: Helm
+        run: |
+          az configure --defaults acr=${CLUSTER_NAME}
+          az acr login -n ${CLUSTER_NAME}
+          cd ./ghrhelm
+          helm package .
+          helm push ghr-${GITHUB_SHA}.tgz oci://${CLUSTER_NAME}.azurecr.io/ghrunner
+      - name: AKS set context
+        uses: azure/aks-set-context@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }} # Azure credentials
+          resource-group: ${{ secrets.RESOURCE_GROUP_NAME }}
+          cluster-name: ${{ env.CLUSTER_NAME }}
+      - name: Deploy
+        run: |
+          az configure --defaults acr=${CLUSTER_NAME}
+          helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version ${GITHUB_SHA}
+          helm install ghrunner ghr-${VERSION}.tgz
+            --set image.repository=${CLUSTER_NAME}.azurecr.io/ghrunner \
+            --set ghr.github_token=${GH_TOKEN} \
+            --set ghr.repo_name=${GITHUB_REPO_NAME} \
+            --set ghr.repo_url=${GITHUB_REPO_URL} \
+            --set ghr.repo_owner=${GITHUB_REPO_OWNER} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ env:
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   REGION: eastus2
   CLUSTER_NAME: githubrunner
+  STORAGE_ACCOUNT_NAME: runnerstorage
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
   
@@ -32,7 +33,6 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run setup.sh
         run: |
-          export STORAGE_ACCOUNT_NAME=$(echo "${RESOURCE_GROUP_NAME}" | tr '[:upper:]' '[:lower:]')$RANDOM
           export CONTAINER_NAME=$(echo "${CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]')tfstate
           az storage account create --resource-group $RESOURCE_GROUP_NAME --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
           export ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,11 @@ env:
   REGION: eastus2
   CLUSTER_NAME: githubrunner
   STORAGE_ACCOUNT_NAME: runnerstorage6594
-  GITHUB_REPO_OWNER: tristanang
-  GITHUB_REPO_NAME: aks-github-runner
+  REPO_OWNER: tristanang
+  REPO_NAME: aks-github-runner
   GITHUB_REPO_URL: https://github.com/tristanang/aks-github-runner
   HELM_EXPERIMENTAL_OCI: 1
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -81,6 +82,6 @@ jobs:
             --set image.repository=${CLUSTER_NAME}.azurecr.io/ghrunner \
             --set image.tag=${GITHUB_SHA} \
             --set ghr.github_token=${GH_TOKEN} \
-            --set ghr.repo_name=${GITHUB_REPO_NAME} \
+            --set ghr.repo_name=${REPO_NAME} \
             --set ghr.repo_url=${GITHUB_REPO_URL} \
-            --set ghr.repo_owner=${GITHUB_REPO_OWNER} \
+            --set ghr.repo_owner=${REPO_OWNER} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
           helm pull oci://${CLUSTER_NAME}.azurecr.io/ghrunner/ghr --version 0.0.1
           helm install ghrunner ghr-0.0.1.tgz
             --set image.repository=${CLUSTER_NAME}.azurecr.io/ghrunner \
+            --set image.tag=${GITHUB_SHA} \
             --set ghr.github_token=${GH_TOKEN} \
             --set ghr.repo_name=${GITHUB_REPO_NAME} \
             --set ghr.repo_url=${GITHUB_REPO_URL} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,48 +1,43 @@
-# This is a basic workflow to help you get started with Actions
-
+# This workflow creates a self-hosted Github Runner on AKS
 name: AKS Self Hosted Runner
 
-# Controls when the workflow will run
-on: [push, workflow_dispatch]
+on: workflow_dispatch
 
 env:
-  # Remember to convert to secret variables before merging
-  SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
-  REGION: eastus2
-  CLUSTER_NAME: githubrunner
-  STORAGE_ACCOUNT_NAME: runnerstorage6594
-  REPO_OWNER: tristanang
-  REPO_NAME: aks-github-runner
-  GITHUB_REPO_URL: https://github.com/tristanang/aks-github-runner
-  HELM_EXPERIMENTAL_OCI: 1
+  REGION: ${{ secrets.REGION }}
+  CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
+  REPO_OWNER: ${{ secrets.REPO_OWNER }}
+  REPO_NAME: ${{ secrets.REPO_NAME }}
+  REPO_URL: ${{ secrets.REPO_URL }}
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  HELM_EXPERIMENTAL_OCI: 1
   
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      # Runs a single command using the runners shell
-      - name: Run setup.sh
+
+      - name: Create storage account and container
         id: setup_storage
         run: |
+          STORAGE_ACCOUNT_NAME=$(echo "$RESOURCE_GROUP_NAME" | tr '[:upper:]' '[:lower:]')$RANDOM
           CONTAINER_NAME=$(echo "${CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]')tfstate
           az storage account create --resource-group $RESOURCE_GROUP_NAME --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
           ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)
           az storage container create --name $CONTAINER_NAME --account-name $STORAGE_ACCOUNT_NAME --account-key $ACCOUNT_KEY
+          echo "::set-output name=container_name::$STORAGE_ACCOUNT_NAME"
           echo "::set-output name=container_name::$CONTAINER_NAME"
           echo "::set-output name=account_key::$ACCOUNT_KEY"
-      - uses: tristanang/aks_create_action@main
+
+      # Create AKS Cluster
+      - uses: Azure/aks_create_action@main
         with:
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
@@ -55,25 +50,31 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
           ACTION_TYPE: create
           CREATE_ACR: true
-      # Build Docker image
-      - name: Build and push image
+
+      - name: Attach ACR to Cluster (bug: missing functionality in aks_create_action)
+        run: az aks update -n $CLUSTER_NAME -g $RESOURCE_GROUP_NAME --attach-acr $CLUSTER_NAME
+
+      - name: Build and push Github Runner image
         run: |
           az configure --defaults acr=${CLUSTER_NAME}
           az acr build -t ghrunner:${GITHUB_SHA} ./ghrdocker
-      - name: Helm
+
+      - name: Create Helm chart
         run: |
           # az configure --defaults acr=${CLUSTER_NAME}
           # az acr login -n ${CLUSTER_NAME}
           cd ./ghrhelm
           helm package .
           # helm push ghr-0.0.1.tgz oci://${CLUSTER_NAME}.azurecr.io/ghrunner
+
       - name: AKS set context
         uses: azure/aks-set-context@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }} # Azure credentials
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
           resource-group: ${{ secrets.RESOURCE_GROUP_NAME }}
           cluster-name: ${{ env.CLUSTER_NAME }}
-      - name: Deploy
+
+      - name: Deploy via Helm
         run: |
           cd ./ghrhelm
           # az configure --defaults acr=${CLUSTER_NAME}
@@ -83,5 +84,5 @@ jobs:
             --set image.tag=${GITHUB_SHA} \
             --set ghr.github_token=${GH_TOKEN} \
             --set ghr.repo_name=${REPO_NAME} \
-            --set ghr.repo_url=${GITHUB_REPO_URL} \
+            --set ghr.repo_url=${REPO_URL} \
             --set ghr.repo_owner=${REPO_OWNER} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,6 @@ jobs:
           ACTION_TYPE: create
           CREATE_ACR: true
 
-      - name: Attach ACR to Cluster
-        run: az aks update -n $CLUSTER_NAME -g $RESOURCE_GROUP_NAME --attach-acr $CLUSTER_NAME
-
       - name: Build and push Github Runner image
         run: |
           az configure --defaults acr=${CLUSTER_NAME}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           ACTION_TYPE: create
           CREATE_ACR: true
 
-      - name: Attach ACR to Cluster (bug: missing functionality in aks_create_action)
+      - name: Attach ACR to Cluster
         run: az aks update -n $CLUSTER_NAME -g $RESOURCE_GROUP_NAME --attach-acr $CLUSTER_NAME
 
       - name: Build and push Github Runner image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,8 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
           ACTION_TYPE: create
           CREATE_ACR: true
+      # Build Docker image
+      - name: Build image
+        run: |
+          az configure --defaults acr=${RESOURCE_GROUP_NAME}
+          az acr build -t ghrunner:${GITHUB_SHA} ./ghrdocker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   REGION: eastus2
   CLUSTER_NAME: githubrunner
-  STORAGE_ACCOUNT_NAME: runnerstorage
+  STORAGE_ACCOUNT_NAME: runnerstorage6594
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ env:
   GITHUB_REPO_OWNER: tristanang
   GITHUB_REPO_NAME: aks-github-runner
   
-  
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -32,14 +31,24 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       # Runs a single command using the runners shell
       - name: Run setup.sh
+        id: setup_storage
         run: |
-          export CONTAINER_NAME=$(echo "${CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]')tfstate
+          CONTAINER_NAME=$(echo "${CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]')tfstate
           az storage account create --resource-group $RESOURCE_GROUP_NAME --name $STORAGE_ACCOUNT_NAME --sku Standard_LRS --encryption-services blob
-          export ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)
+          ACCOUNT_KEY=$(az storage account keys list --resource-group $RESOURCE_GROUP_NAME --account-name $STORAGE_ACCOUNT_NAME --query '[0].value' -o tsv)
           az storage container create --name $CONTAINER_NAME --account-name $STORAGE_ACCOUNT_NAME --account-key $ACCOUNT_KEY
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          echo "::set-output name=container_name::$CONTAINER_NAME"
+          echo "::set-output name=account_key::$ACCOUNT_KEY"
+      - uses: tristanang/aks_create_action@main
+        with:
+          CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
+          STORAGE_ACCOUNT_NAME: ${{ env.STORAGE_ACCOUNT_NAME }}
+          STORAGE_CONTAINER_NAME: ${{ steps.setup_storage.outputs.container_name }}
+          STORAGE_ACCESS_KEY: ${{ steps.setup_storage.outputs.account_key }}
+          ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
+          ACTION_TYPE: create
+          CREATE_ACR: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on: workflow_dispatch
 
 env:
   # Remember to convert to secret variables before merging
+  SUBSCRIPTION_ID: $(echo ${{ secrets.AZURE_CREDENTIALS }} | jq -r .appId)
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   CLUSTER_NAME: githubrunner
   GITHUB_REPO_OWNER: tristanang

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ deploy:
 	helm pull oci://${RESOURCE_GROUP_NAME}.azurecr.io/ghrunner/ghr --version ${VERSION} && \
 	helm install ghrunner ghr-${VERSION}.tgz \
 	--set image.repository=${RESOURCE_GROUP_NAME}.azurecr.io/ghrunner \
-	--set ghr.github_token=${GITHUB_TOKEN} && \
+	--set ghr.github_token=${GH_TOKEN} && \
 	--set ghr.repo_name=${GITHUB_REPO_NAME} && \
 	--set ghr.repo_url=${GITHUB_REPO_URL} && \
 	--set ghr.repo_owner=${GITHUB_REPO_OWNER} && \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure you have the following dependencies:
 - [jq](https://stedolan.github.io/jq/download/)
 - [azure-cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) (logged in to a subscription where you have contributor rights)
 - [github-cli](https://cli.github.com/) (logged in)
-- [Create a github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) -- and export the value -- export GITHUB_TOKEN=paste_your_token_here
+- [Create a github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) -- and export the value -- export GH_TOKEN=paste_your_token_here
 
 Run the setup.sh script
 - Syntax: **. ./setup.sh** [-c CLUSTER_NAME] [-g RESOURCE_GROUP_NAME] [-s SUBSCRIPTION_ID] [-r REGION] (the extra dot is important)
@@ -38,7 +38,7 @@ This uses the repo makefile to create your AKS cluster, create an ACR, and deplo
 ## Next steps
 
 - dynamically set repo owner/repo name
-- check for GITHUB_TOKEN before deploying
+- check for GH_TOKEN before deploying
 - remove helm install note
 - check for all other variables in makefile (gh secret get?)
 - add workflow / instructions

--- a/ghrdocker/entrypoint.sh
+++ b/ghrdocker/entrypoint.sh
@@ -4,7 +4,7 @@ set -eEuo pipefail
 ACTIONS_RUNNER_INPUT_NAME=$HOSTNAME
 export RUNNER_ALLOW_RUNASROOT=1
 
-TOKEN="$(curl -sS --request POST --url "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/runners/registration-token" --header "authorization: Bearer ${GITHUB_TOKEN}"  --header 'content-type: application/json' | jq -r .token)"
+TOKEN="$(curl -sS --request POST --url "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/runners/registration-token" --header "authorization: Bearer ${GH_TOKEN}"  --header 'content-type: application/json' | jq -r .token)"
 
 /actions-runner/config.sh --unattended --replace --work "/tmp" --url "$ACTIONS_RUNNER_INPUT_URL" --token "$TOKEN" --labels aks-runner
 /actions-runner/bin/runsvc.sh

--- a/ghrhelm/templates/deployment.yaml
+++ b/ghrhelm/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
                   [
                     "/bin/bash",
                     "-c",
-                    'RUNNER_ALLOW_RUNASROOT=1 ./config.sh remove --token $(curl -sS --request POST --url "https://api.github.com/repos/{{ .Values.ghr.repo_owner }}/{{ .Values.repo_name }}/actions/runners/remove-token" --header "authorization: Bearer ${GITHUB_TOKEN}"  --header "content-type: application/json" | jq -r .token)',
+                    'RUNNER_ALLOW_RUNASROOT=1 ./config.sh remove --token $(curl -sS --request POST --url "https://api.github.com/repos/{{ .Values.ghr.repo_owner }}/{{ .Values.repo_name }}/actions/runners/remove-token" --header "authorization: Bearer ${GH_TOKEN}"  --header "content-type: application/json" | jq -r .token)',
                   ]   
           ports:
             - name: https

--- a/ghrhelm/templates/secret.yaml
+++ b/ghrhelm/templates/secret.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "ghr.labels" . | nindent 4 }}
 type: Opaque
 data:
-  GITHUB_TOKEN: {{ default "" .Values.ghr.github_token | b64enc | quote }}
+  GH_TOKEN: {{ default "" .Values.ghr.github_token | b64enc | quote }}


### PR DESCRIPTION
Documentation will be added in a subsequent PR since it needs to be updated for issues unrelated to the workflow.
Workflow does not work as is because aks_create_action does not attach-acr to cluster, which will be fixed separately.
To make things work in the current state, 
`az aks update -n myAKSCluster -g myResourceGroup --attach-acr <acr-name>`
needs to be run from the terminal locally (after the cluster is created).